### PR TITLE
[Feat] #8 - 로그인, 로그아웃 기능 구현

### DIFF
--- a/sse/src/main/java/com/sse/sse/common/MyUtil.java
+++ b/sse/src/main/java/com/sse/sse/common/MyUtil.java
@@ -3,7 +3,7 @@ package com.sse.sse.common;
 import java.util.Scanner;
 
 public class MyUtil {
-    public static String checkInputText(String target, String inputMessage) {
+    public static String checkInputText(final String target, final String inputMessage) {
         Scanner sc = new Scanner(System.in);
         String input = "";
 

--- a/sse/src/main/java/com/sse/sse/controller/MemberController.java
+++ b/sse/src/main/java/com/sse/sse/controller/MemberController.java
@@ -12,7 +12,7 @@ public class MemberController {
         String email = "";
         while(true) {
             email = MyUtil.checkInputText("이메일", "이메일을 입력해주세요: ");
-            if (!memberService.isDuplicateEmail(email)) break;
+            if (memberService.getMemberId(email) < 0) break;
             System.out.println("중복된 이메일입니다.");
         }
         String password = MyUtil.checkInputText("비밀번호", "비밀번호를 입력해주세요: ");

--- a/sse/src/main/java/com/sse/sse/controller/MemberController.java
+++ b/sse/src/main/java/com/sse/sse/controller/MemberController.java
@@ -45,4 +45,16 @@ public class MemberController {
         }
     }
 
+    public void signOut() {
+        System.out.println("로그아웃을 시작합니다.");
+
+        String email = MyUtil.checkInputText("이메일", "이메일을 입력해주세요: ");
+        if(memberService.getMemberId(email) < 0) {
+            System.out.println("회원이 아닙니다.");
+        } else if(!memberService.signOut(email)) {
+            System.out.println("현재 로그인 상태가 아닙니다.");
+        } else {
+            System.out.println("로그아웃에 성공하였습니다.");
+        }
+    }
 }

--- a/sse/src/main/java/com/sse/sse/controller/MemberController.java
+++ b/sse/src/main/java/com/sse/sse/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.sse.sse.controller;
 
 import com.sse.sse.common.MyUtil;
+import com.sse.sse.dto.member.SignInDto;
 import com.sse.sse.dto.member.SignupDto;
 import com.sse.sse.service.MemberService;
 
@@ -26,4 +27,22 @@ public class MemberController {
             System.out.println("회원 가입에 실패하였습니다.");
         }
     }
+
+    public void signIn() {
+        System.out.println("로그인을 시작합니다.");
+
+        String email = MyUtil.checkInputText("이메일", "이메일을 입력해주세요: ");
+        String password = MyUtil.checkInputText("비밀번호", "비밀번호를 입력해주세요: ");
+
+        SignInDto dto = new SignInDto(email, password);
+        Long attemptMemberId = memberService.signIn(dto);
+
+        if (attemptMemberId > 0) {
+            System.out.println("로그인에 성공하였습니다.");
+            memberService.putSignedInMember(attemptMemberId);
+        } else {
+            System.out.println("로그인에 실패하였습니다. 아이디/비밀번호를 다시 확인해주세요");
+        }
+    }
+
 }

--- a/sse/src/main/java/com/sse/sse/dto/member/SignInDto.java
+++ b/sse/src/main/java/com/sse/sse/dto/member/SignInDto.java
@@ -7,7 +7,7 @@ public class SignInDto {
     public SignInDto() {
     }
 
-    public SignInDto(String email, String password) {
+    public SignInDto(final String email, final String password) {
         this.email = email;
         this.password = password;
     }

--- a/sse/src/main/java/com/sse/sse/dto/member/SignInDto.java
+++ b/sse/src/main/java/com/sse/sse/dto/member/SignInDto.java
@@ -1,0 +1,22 @@
+package com.sse.sse.dto.member;
+
+public class SignInDto {
+    private String email;
+    private String password;
+
+    public SignInDto() {
+    }
+
+    public SignInDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/sse/src/main/java/com/sse/sse/dto/member/SignupDto.java
+++ b/sse/src/main/java/com/sse/sse/dto/member/SignupDto.java
@@ -8,7 +8,7 @@ public class SignupDto {
     public SignupDto() {
     }
 
-    public SignupDto(String email, String password, String nickname) {
+    public SignupDto(final String email, final String password, final String nickname) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/sse/src/main/java/com/sse/sse/repository/MemberRepository.java
+++ b/sse/src/main/java/com/sse/sse/repository/MemberRepository.java
@@ -4,10 +4,13 @@ import com.sse.sse.aggregate.Member;
 import com.sse.sse.config.stream.MyObjectOutput;
 
 import java.io.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MemberRepository {
     private final ArrayList<Member> memberList = new ArrayList<>();
+    private static final ConcurrentHashMap<Long, LocalDateTime> signedInMember = new ConcurrentHashMap<>();
     private final File file
             = new File("src/main/java/com/sse/sse/db/member.dat");
 
@@ -77,5 +80,10 @@ public class MemberRepository {
         }
 
         return result;
+    }
+
+    public void putSignedInMember(Long attemptMemberId) {
+        signedInMember.put(attemptMemberId, LocalDateTime.now());
+        System.out.println(signedInMember);
     }
 }

--- a/sse/src/main/java/com/sse/sse/repository/MemberRepository.java
+++ b/sse/src/main/java/com/sse/sse/repository/MemberRepository.java
@@ -84,6 +84,15 @@ public class MemberRepository {
 
     public void putSignedInMember(Long attemptMemberId) {
         signedInMember.put(attemptMemberId, LocalDateTime.now());
-        System.out.println(signedInMember);
+//        System.out.println(signedInMember);
+    }
+
+    public LocalDateTime getSignedInTime(Long memberId) {
+        return signedInMember.get(memberId);
+    }
+
+    public void removeSignedInMember(Long memberId) {
+        signedInMember.remove(memberId);
+//        System.out.println(signedInMember);
     }
 }

--- a/sse/src/main/java/com/sse/sse/repository/MemberRepository.java
+++ b/sse/src/main/java/com/sse/sse/repository/MemberRepository.java
@@ -52,7 +52,7 @@ public class MemberRepository {
         return result;
     }
 
-    public int signup(Member newMember) {
+    public int signup(final Member newMember) {
         ObjectOutputStream oos = null;
         int result = 0;
 
@@ -82,16 +82,16 @@ public class MemberRepository {
         return result;
     }
 
-    public void putSignedInMember(Long attemptMemberId) {
+    public void putSignedInMember(final Long attemptMemberId) {
         signedInMember.put(attemptMemberId, LocalDateTime.now());
 //        System.out.println(signedInMember);
     }
 
-    public LocalDateTime getSignedInTime(Long memberId) {
+    public LocalDateTime getSignedInTime(final Long memberId) {
         return signedInMember.get(memberId);
     }
 
-    public void removeSignedInMember(Long memberId) {
+    public void removeSignedInMember(final Long memberId) {
         signedInMember.remove(memberId);
 //        System.out.println(signedInMember);
     }

--- a/sse/src/main/java/com/sse/sse/service/MemberService.java
+++ b/sse/src/main/java/com/sse/sse/service/MemberService.java
@@ -2,6 +2,7 @@ package com.sse.sse.service;
 
 import com.sse.sse.aggregate.Member;
 import com.sse.sse.aggregate.enums.MemberStatus;
+import com.sse.sse.dto.member.SignInDto;
 import com.sse.sse.dto.member.SignupDto;
 import com.sse.sse.repository.MemberRepository;
 
@@ -31,5 +32,22 @@ public class MemberService {
                 MemberStatus.ACTIVE
         );
         return memberRepository.signup(newMember);
+    }
+
+    public Long signIn(SignInDto dto) {
+        Long result = -1L;
+
+        ArrayList<Member> memberList = memberRepository.findAllMembers();
+        for (Member member : memberList) {
+            if(member.getEmail().equals(dto.getEmail()) && member.getPassword().equals(dto.getPassword())) {
+                result = getMemberId(dto.getEmail());
+            }
+        }
+
+        return result;
+    }
+
+    public void putSignedInMember(Long attemptMemberId) {
+        memberRepository.putSignedInMember(attemptMemberId);
     }
 }

--- a/sse/src/main/java/com/sse/sse/service/MemberService.java
+++ b/sse/src/main/java/com/sse/sse/service/MemberService.java
@@ -10,14 +10,14 @@ import java.util.ArrayList;
 public class MemberService {
     private final MemberRepository memberRepository = new MemberRepository();
 
-    public boolean isDuplicateEmail(String inputEmail) {
+    public Long getMemberId(String inputEmail) {
         ArrayList<Member> memberList = memberRepository.findAllMembers();
         for (Member member : memberList) {
             if(member.getEmail().equals(inputEmail)) {
-                return true;
+                return member.getId();
             }
         }
-        return false;
+        return -1L;
     }
 
     public int signup(SignupDto dto) {

--- a/sse/src/main/java/com/sse/sse/service/MemberService.java
+++ b/sse/src/main/java/com/sse/sse/service/MemberService.java
@@ -55,11 +55,9 @@ public class MemberService {
     public boolean signOut(final String email) {
         Long memberId = getMemberId(email);
 
-        if(memberId > 0) {
-            if(memberRepository.getSignedInTime(memberId) != null) {
-                memberRepository.removeSignedInMember(memberId);
-                return true;
-            }
+        if(memberRepository.getSignedInTime(memberId) != null) {
+            memberRepository.removeSignedInMember(memberId);
+            return true;
         }
 
         return false;

--- a/sse/src/main/java/com/sse/sse/service/MemberService.java
+++ b/sse/src/main/java/com/sse/sse/service/MemberService.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 public class MemberService {
     private final MemberRepository memberRepository = new MemberRepository();
 
-    public Long getMemberId(String inputEmail) {
+    public Long getMemberId(final String inputEmail) {
         ArrayList<Member> memberList = memberRepository.findAllMembers();
         for (Member member : memberList) {
             if(member.getEmail().equals(inputEmail)) {
@@ -22,7 +22,7 @@ public class MemberService {
         return -1L;
     }
 
-    public int signup(SignupDto dto) {
+    public int signup(final SignupDto dto) {
         Long newMemberId = memberRepository.getLastMemberId() + 1;
         Member newMember = new Member(
                 newMemberId,
@@ -35,7 +35,7 @@ public class MemberService {
         return memberRepository.signup(newMember);
     }
 
-    public Long signIn(SignInDto dto) {
+    public Long signIn(final SignInDto dto) {
         Long result = -1L;
 
         ArrayList<Member> memberList = memberRepository.findAllMembers();
@@ -48,11 +48,11 @@ public class MemberService {
         return result;
     }
 
-    public void putSignedInMember(Long attemptMemberId) {
+    public void putSignedInMember(final Long attemptMemberId) {
         memberRepository.putSignedInMember(attemptMemberId);
     }
 
-    public boolean signOut(String email) {
+    public boolean signOut(final String email) {
         Long memberId = getMemberId(email);
 
         if(memberId > 0) {

--- a/sse/src/main/java/com/sse/sse/service/MemberService.java
+++ b/sse/src/main/java/com/sse/sse/service/MemberService.java
@@ -6,6 +6,7 @@ import com.sse.sse.dto.member.SignInDto;
 import com.sse.sse.dto.member.SignupDto;
 import com.sse.sse.repository.MemberRepository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 public class MemberService {
@@ -49,5 +50,18 @@ public class MemberService {
 
     public void putSignedInMember(Long attemptMemberId) {
         memberRepository.putSignedInMember(attemptMemberId);
+    }
+
+    public boolean signOut(String email) {
+        Long memberId = getMemberId(email);
+
+        if(memberId > 0) {
+            if(memberRepository.getSignedInTime(memberId) != null) {
+                memberRepository.removeSignedInMember(memberId);
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## ISSUE
- #8 

## Develop
### 1️⃣ 로그인
> 이메일, 비밀번호를 입력해 로그인합니다.
- 회원 리스트에 일치하는 이메일, 비밀번호가 있으면 해당 회원의 id 리턴
- 로그인 성공 시, 현재 로그인한 회원을 관리하는 `signedInMember` 에 회원 id와 로그인 일시 put함
- `signedInMember`의 데이터 타입을 `ConcurrentHashMap<Long, Date>`에서 `ConcurrentHashMap<Long, LocalDateTime>`으로 변경 (`LocalDateTime.now()` 활용을 위해)

### 2️⃣ 로그아웃
> 이메일을 입력해 로그아웃합니다.
- 입력한 이메일과 일치하는 회원이 없으면 `"회원이 아닙니다."` 문구 출력
- `signedInMember`에 없는 회원이면 `"현재 로그인 상태가 아닙니다."` 문구 출력
- `signedInMember`에 있는 회원이면 해당 회원을 `signedInMember`에서 remove하고 로그아웃 성공 문구 출력

## Test
![test](https://github.com/user-attachments/assets/681f65c8-51ce-4902-987b-d75ee017715e)

